### PR TITLE
change twap avg to weighted

### DIFF
--- a/tests/rust-tests/src/live_debugging/test_specific_config.rs
+++ b/tests/rust-tests/src/live_debugging/test_specific_config.rs
@@ -30,7 +30,7 @@ use crate::{
 use super::types::Balances;
 
 const ACCOUNT_ADDR: &str = "neutron1yd27kgnsjkeddwtuy29q9yzrnd247v6hcml6swl54dfkcwuuytqs8ha94x";
-const HEIGHT: &str = "";
+const HEIGHT: &str = "a";
 
 #[ignore = "For debugging mainnet data"]
 #[test]
@@ -38,6 +38,8 @@ fn live_debugging() {
     // If we have specifig height, query by that height
     let mut height_arg = vec![];
     let mut block_height = vec![];
+
+    #[allow(clippy::const_is_empty)]
     if !HEIGHT.is_empty() {
         height_arg = vec!["--height", HEIGHT];
         block_height = vec![HEIGHT];

--- a/tests/rust-tests/src/tests_rebalancer/test_management.rs
+++ b/tests/rust-tests/src/tests_rebalancer/test_management.rs
@@ -265,7 +265,7 @@ fn test_update_whitelist() {
     let whitelist = suite.query_rebalancer_whitelists().unwrap();
 
     // lets make sure the whitelist is what we expect for the tests
-    assert!(whitelist.denom_whitelist.contains(&ATOM.to_string()));
+    assert!(whitelist.denom_whitelist.contains(ATOM));
     assert!(whitelist.denom_whitelist.len() == 3);
     assert!(whitelist
         .base_denom_whitelist
@@ -282,8 +282,8 @@ fn test_update_whitelist() {
         .unwrap();
 
     let whitelist = suite.query_rebalancer_whitelists().unwrap();
-    assert!(!whitelist.denom_whitelist.contains(&ATOM.to_string()));
-    assert!(!whitelist.denom_whitelist.contains(&NTRN.to_string()));
+    assert!(!whitelist.denom_whitelist.contains(ATOM));
+    assert!(!whitelist.denom_whitelist.contains(NTRN));
     assert!(whitelist.denom_whitelist.len() == 2);
 
     // remove atom, add random


### PR DESCRIPTION
We changed the avg calculation to be weighted avg, the more recent the price is, the more weight it has, and we only include prices in the last 10 days for the avg.